### PR TITLE
Remove Bevy default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "Allows to trigger web/dom based popups/alerts and textinput in be
 default-target = "wasm32-unknown-unknown"
 
 [dependencies]
-bevy = { version = "0.13" }
+bevy = { version = "0.13", default-features=false }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 gloo = { version = "0.11", features = ["utils"] }


### PR DESCRIPTION
We aren't using them and were unnecessarily bringing features into other crates, causing performance issues.