### PR TITLE
Update to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ description = "Allows to trigger web/dom based popups/alerts and textinput in be
 default-target = "wasm32-unknown-unknown"
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
+bevy = { version = "0.14", default-features = false }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 gloo = { version = "0.11", features = ["utils"] }
-bevy_crossbeam_event = "0.5"
+bevy_crossbeam_event = "0.6"
 
 [target.'cfg(target_family = "wasm")'.dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
# Objective
Update to Bevy version 0.14

## Solution
Change the Bevy version in Cargo.toml to 0.14, and update bevy_crossbeam_event. And bump crate version to 0.2 to signify this update.

## Testing
Ran `cargo clippy` and `cargo test`, and neither failed.